### PR TITLE
Adds AgnosticUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Design System - [A comprehensive guide to design systems](https://www.invisionap
 
 ## Resources
 
+-   [AgnosticUI](https://www.agnosticui.com/) - Accessible React component primitives that also work with Vue 3, Svelte, and Angular! ([GitHub](https://github.com/AgnosticUI/agnosticui), [Demo](https://developtodesign.com/agnosticui-examples))
 -   [Awesome UI component library](https://github.com/anubhavsrivastava/awesome-ui-component-library) for component library implementation (React, Vue, Angular, etc) for styleguides
 -   [Google Design](https://design.google/) - Cooperative effort led by a group of designers, writers, and developers at Google to publish original content, produce events, and foster creative and educational partnerships that advance design and technology.
 


### PR DESCRIPTION
Added `#design name` entry

Hi @anubhavsrivastava -- this adds AgnosticUI to the Resources section in alphabetical ordering:

![image](https://user-images.githubusercontent.com/142403/161165105-e95ebca5-96bf-4e4c-9a84-1806b0dc66af.png)

Lmk if this is good 🙏  🚀 
